### PR TITLE
Subtle repo tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Archive-It Utilties is a Python library for extracting information from Archive-
 
 ## Installation
 
-This package is called `aiu` on PyPI. Installation is handled via `pip`:
+This package requires Python 3 and is called `aiu` on PyPI. Installation is handled via `pip`:
 
 `pip install aiu`
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description='Tools for for interacting with Archive-It.',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/shawnmjones/archiveit_utilities',
+    url='https://github.com/oduwsdl/archiveit_utilities',
     author='Shawn M. Jones',
     author_email='jones.shawn.m@gmail.com',
     license='MIT',


### PR DESCRIPTION
My system was still configured to use Python 2 by default. This produced an error when installing via pip using pypi. In pypi, the requirement for aiu listed as Python 3(.6), so I figured stating this in the README might save someone some time.

Also, I updated the repo listing, which is used in the pypi web interface.